### PR TITLE
Modified bamConcordance to close correct files.

### DIFF
--- a/concordance/bamConcordance
+++ b/concordance/bamConcordance
@@ -252,10 +252,11 @@ def main():
 
     # Close input files
     inbam.close()
-    outbam.close()
+    reffasta.close()
 
     # Close output file
-    outbam.close()
+    if outbam:
+        outbam.close()
     outcsv.close()
 
 


### PR DESCRIPTION
Currently, `outbam.close()` is always run, causing the following error when the argument is not used:

```
Traceback (most recent call last):
  File "./hg002-ccs/concordance/bamConcordance", line 265, in <module>
    main()
  File "./hg002-ccs/concordance/bamConcordance", line 256, in main
    outbam.close()
AttributeError: 'NoneType' object has no attribute 'close'
```